### PR TITLE
Fixed a small problem when using let's encrypt certificates

### DIFF
--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -103,6 +103,11 @@ func NewClient(c *ClientConfig) (*Client, error) {
 
 	//config
 	client.tcpConfig = &tcpConfig{tfo: c.EnableTFO, vpnMode: c.VpnMode}
+	if host, _, err := net.SplitHostPort(c.ServerName); err == nil {
+		c.ServerName = host
+	} else {
+		client.log.Error("Cannot get the host address from the server address")
+	}
 	client.tlsConf = &tls.Config{
 		InsecureSkipVerify: c.InsecureSkipVerify,
 		ServerName:         c.ServerName,


### PR DESCRIPTION
Hello
I found a small problem when using let's encrypt (or maybe other) certificates.
Before this commit, the server name was something like `my.domain.com:443` and certificates usually use `my.domain.com`. (They do not include IP in them)
For example before this commit, I used to get this error without the `-sv` argument and Let's Encrypt certificates:
```
time="2020-02-23T10:06:08+03:30" level=error msg="connect to remote: x509: certificate is valid for my.domain.com, my.domain.com:443"
```
But with this commit, I was able to connect to my server without any problem.